### PR TITLE
Upgrade puma 6.6.1 -> 7.2.1 (CVE-2026-47736/47737)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :production do
 end
 
 # Use Puma as the app server
-gem 'puma', '~> 6.4'
+gem 'puma', '~> 7.2'
 
 # Use Capistrano for deployment
 # gem 'capistrano', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.6.1)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -252,7 +252,7 @@ DEPENDENCIES
   jbuilder (~> 2.11)
   jsbundling-rails
   pg (~> 1.5)
-  puma (~> 6.4)
+  puma (~> 7.2)
   rails (~> 8.0.5)
   rspec-rails (~> 6.0)
   sdoc


### PR DESCRIPTION
Closes the two open High-severity Dependabot alerts on `Gemfile.lock`.

## What

| | Before | After |
|---|---|---|
| `Gemfile` | `gem 'puma', '~> 6.4'` | `gem 'puma', '~> 7.2'` |
| `Gemfile.lock` | `puma (6.6.1)` | `puma (7.2.1)` |

No transitive dependency churn — puma is the only gem that moved.

## Why

| CVE | Summary | Patched |
|---|---|---|
| CVE-2026-47736 | PROXY Protocol v1 parser allows remote memory exhaustion | 7.2.1 |
| CVE-2026-47737 | PROXY Protocol v1 accepts repeated protocol headers on persistent connections | 7.2.1 |

Vulnerable range is `>= 5.5.0, < 7.2.1`. The fix is only available in 7.x, so the old `~> 6.4` constraint could not reach it — this needs a deliberate major bump, which is why Dependabot could not auto-resolve it.

**Current exposure is nil.** Both bugs live in the PROXY protocol v1 parser, which is opt-in via `set_remote_address proxy_protocol: :v1`. `config/puma.rb` does not enable it. This closes the alerts and covers us if the app is ever placed behind a proxy-protocol load balancer.

## Puma 7 migration notes

Low risk here:

- `config/puma.rb` is the stock Rails 8 file with no worker hooks, so none of Puma 7's renamed callbacks (`on_worker_boot` -> `before_worker_boot`, etc.) apply.
- Ruby 3.2.3 satisfies Puma 7's 3.0+ floor.
- Response headers are now lowercase — Rack 3.2.6 already normalized these, so no effect.
- `preload_app!` is now default in clustered mode. We run single mode, so no impact today; worth remembering if `WEB_CONCURRENCY` is ever set in production.

## Verification

:warning: **The rspec suite is empty** — `spec/` contains only `spec_helper.rb` and zero `_spec.rb` files, so `bundle exec rspec` reports `0 examples, 0 failures`. It passes because there is nothing in it, and provided no signal on this change.

Validated by booting the app instead:

- Clean boot on Rails 8.0.5 / puma 7.2.1, no deprecation warnings
- `GET /` -> 200, layout and `home/index` rendered, session cookie set
- `GET /home/index` -> 200
- unknown path -> 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)