### PR TITLE
Add request specs for / and /home/index

### DIFF
--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+# Both routes point at HomeController#index -- `root` and the explicit
+# `get 'home/index'` -- so each is exercised separately to catch either one
+# being changed or removed on its own.
+describe 'Home', type: :request do
+  shared_examples 'the home page' do |path|
+    it 'responds with 200 OK' do
+      get path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'renders HTML' do
+      get path
+      expect(response.media_type).to eq('text/html')
+    end
+
+    it 'renders the home#index template inside the application layout' do
+      get path
+      expect(response.body).to include('Welcome to FieldRouter')
+      expect(response.body).to include('<title>FieldRouter</title>')
+    end
+
+    it 'renders the map containers the stimulus controller binds to' do
+      get path
+      expect(response.body).to include('data-controller="map"')
+      expect(response.body).to include('id="map1"')
+      expect(response.body).to include('id="map2"')
+    end
+  end
+
+  describe 'GET /' do
+    it_behaves_like 'the home page', '/'
+  end
+
+  describe 'GET /home/index' do
+    it_behaves_like 'the home page', '/home/index'
+  end
+
+  it 'serves the same page from both routes' do
+    get '/'
+    root_body = response.body
+
+    get '/home/index'
+    expect(response.body).to eq(root_body)
+  end
+
+  # show_exceptions is :rescuable in the test env, so a routing miss comes back
+  # as a rendered 404 rather than a raised ActionController::RoutingError.
+  it 'returns 404 for an unrouted path' do
+    get '/no-such-page'
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -18,7 +17,7 @@ RSpec.configure do |config|
   # config.mock_with :rr
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Gives the suite actual regression signal for the first time.

## Why

`spec/` previously held only `spec_helper.rb` and **zero `_spec.rb` files**, so `bundle exec rspec` reported `0 examples, 0 failures` — passing because it was empty. That's why the recent puma 6 -> 7 upgrade (#38) had to be verified by hand-booting the app; the suite would have stayed green no matter what broke.

## What

New `spec/requests/home_spec.rb`. Both routes reach `HomeController#index` (`root` and the explicit `get 'home/index'`), so a shared example runs against each path separately — either one being changed or removed on its own now fails.

| Coverage | `/` | `/home/index` |
|---|---|---|
| 200 OK | ✅ | ✅ |
| `text/html` media type | ✅ | ✅ |
| `home#index` renders inside the application layout | ✅ | ✅ |
| Map hooks (`data-controller="map"`, `#map1`, `#map2`) | ✅ | ✅ |

Plus body parity between the two routes, and a 404 on an unrouted path.

The map-container assertion is the one with teeth — it pins the DOM hooks the Stimulus `map` controller binds to, so a view edit that silently breaks the JS wiring fails the suite.

## spec_helper.rb fixes

Two changes were required for a clean run; the harness was Rails 3-era:

- `config.fixture_path=` -> `config.fixture_paths=` (singular deprecated in Rails 7.1; plural takes an array).
- Removed `require 'rspec/autorun'` — deprecated when running via the `rspec` command, and it warned on every run.

## Verification

```
10 examples, 0 failures
```

No deprecation warnings remain. And confirmed the specs actually bite rather than pass vacuously — temporarily removing the `home/index` route produces **4 failures**:

```
Home serves the same page from both routes
Home GET /home/index behaves like the home page responds with 200 OK
Home GET /home/index behaves like the home page renders the home#index template ...
Home GET /home/index behaves like the home page renders the map containers ...
```

Note: the 404 example asserts a rendered 404 rather than a raised `ActionController::RoutingError`, because `config/environments/test.rb:26` sets `show_exceptions = :rescuable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)